### PR TITLE
fix pagination logic

### DIFF
--- a/app/modules/github/github.psm1
+++ b/app/modules/github/github.psm1
@@ -48,16 +48,18 @@ function Invoke-GithubApi {
   if ($method -eq 'GET') {
     if ($query) {
       Write-Log -Level INFO -Source 'github' -Message "Adding Query $query to GET call"
-      $queryString = "?$query"
+      $queryString = "?$query&per_page=1000"
     }
 
     # If this is a paginated response we need to walk it
-    Write-Log -Level INFO -Source 'github' -Message "Making initial $method call to find out response information"
+    Write-Log -Level INFO -Source 'github' -Message "Making initial $method call to find out response information https://$apiRoot/$endpoint$queryString"
     $response = Invoke-WebRequest -Method $method -Uri "https://$apiRoot/$endpoint$queryString" -Headers $headers -UseBasicParsing -ErrorAction Stop
+    $items = ConvertFrom-Json $response.Content
+
     # items is a special word in pwsh and using a if resp.items leads to bad results
     if ($response.RelationLink.next -or ($response.content -like '*"items":*')) {
       Write-Log -Level INFO -Source 'github' -Message "Response is Paginated, getting all results"
-      return Get-GithubApiPaginatedResponse -uri "https://$apiRoot/$endpoint$queryString" -Headers $Headers -ErrorAction Stop
+      return $items.items + (Get-GithubApiPaginatedResponse -uri $response.RelationLink.next -Headers $Headers -ErrorAction Stop)
     }
     # We use an index here due to how diff powershell object behave
     # elseif ($responseContent.items[0]) {
@@ -66,7 +68,7 @@ function Invoke-GithubApi {
     # }
     else {
       Write-Log -Level INFO -Source 'github' -Message "Returning results object"
-      return ConvertFrom-Json $response.Content
+      return $items
       #return $responseContent
     }
   }
@@ -82,24 +84,21 @@ function Get-GithubApiPaginatedResponse {
   param(
     [String]
     $uri,
-    [Array]
-    $responseItems = @(),
     [Hashtable]
     $Headers = @{'accept' = 'application/json' }
   )
   $response = Invoke-WebRequest -Method 'GET' -Uri $uri -Headers $headers -UseBasicParsing -ErrorAction Stop
   $responseJson = ($response.content | ConvertFrom-Json)
-  if ($responseJson.GetType().BaseType.Name -eq 'Array')
-  {
-    $responseItems += $responseJson
+  if ($responseJson.GetType().BaseType.Name -eq 'Array') {
+    $responseItems = $responseJson
   }
   else {
-    $responseItems += $responseJson.items
+    $responseItems = $responseJson.items
   }
 
   if ($response.RelationLink.next) {
     Write-Log -Level INFO -Source 'github' -Message "Getting next page of items"
-    $responseItems += Get-GithubApiPaginatedResponse -uri $response.RelationLink.next
+    $responseItems += Get-GithubApiPaginatedResponse -uri $response.RelationLink.next -Headers $Headers
   }
   return $responseItems
 }


### PR DESCRIPTION

# Description

Pagination is broken:
1. Auth headers aren't sent so it fails
1. The first page is fetched again
1. Double appending duplicates results

[github-file-manager](/Xorima/github-file-manager/blob/master/app/modules/github/github.psm1) has the same flaw

## Check List

- [ ] All tests pass
- [ ] New functionality includes testing
- [ ] New functionality has been documented in the CHANGELOG
- [ ] New functionality has been documented in the README if applicable
